### PR TITLE
Add a post-install hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Getting started
 Welcome to the Aurelius Atlas solution powered by Apache Atlas! Aurelius Atlas is an open-source Data Governance solution, based on a selection of open-source tools to facilitate business users to access governance information in an easy consumable way and meet the data governance demands of the distributed data world.
 
 
-Here you will find the instillation instructions and the required setup of the kubernetes instructions, followed by how to deploy the chart in different namespaces. 
+Here you will find the instillation instructions and the required setup of the kubernetes instructions, followed by how to deploy the chart in different namespaces.
 
 Installation Requirements
 -------------------------
@@ -14,13 +14,13 @@ Installation Requirements
 This installation assumes that you have:
 - A kubernetes cluster running
   - with 2 Node of CPU 4 and 16GB
-- Chosen cloud Cli installed 
+- Chosen cloud Cli installed
   - [gcloud](https://cloud.google.com/sdk/docs/install#deb)
   - [az](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli)
 - kubectl installed and linked to chosen cloud Cli
   - [gcloud linked](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#gcloud)
   - [az linked](https://learn.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-cli#connect-to-the-cluster)
-- Helm installed locally 
+- Helm installed locally
 - A DomainName
   - Not necessary for Azure
 
@@ -49,7 +49,7 @@ The certificate manager here is [cert-manager](https://cert-manager.io/docs/inst
 ```bash
 helm repo add jetstack https://charts.jetstack.io
 helm repo update
-helm install  cert-manager jetstack/cert-manager   --namespace cert-manager   --create-namespace   --version v1.9.1   --set   installCRDs=true   
+helm install  cert-manager jetstack/cert-manager   --namespace cert-manager   --create-namespace   --version v1.9.1   --set   installCRDs=true
 ```
 
 - On GKE environment also add ``--set global.leaderElection.namespace=cert-manager`` to the helm install command ([explanation](https://cert-manager.io/docs/installation/compatibility/#gke))
@@ -62,7 +62,7 @@ helm install  cert-manager jetstack/cert-manager   --namespace cert-manager   --
   ```
 
 ##### 2. Install Ingress Nginx Controller
-Only install if you do not have an Ingress Controller. 
+Only install if you do not have an Ingress Controller.
 
 ```bash
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -91,7 +91,7 @@ cd charts/zookeeper/
 helm dependency update
 ```
 
-## Get Ingress Controller External IP to link to DNS 
+## Get Ingress Controller External IP to link to DNS
 Only do this if your ingress controller does not already have a DNS applied. In the case of Azure this is not necessary, other possible instructions can be found below in Azure DNS Label
 ##### Get External IP to link to DNS
 ```bash
@@ -113,7 +113,7 @@ Resulting DNS will be ``<label>.westeurope.cloudapp.azure.com``
 ## Put SSL certificate in a Secret
 
 ##### Define a cluster issuer
-This is needed if you installed cert-manager from the required packages. 
+This is needed if you installed cert-manager from the required packages.
 
 Here we define a ClusterIssuer using cert-manager on the cert-manager namespace:
 1. Move to the directory of Aurelius-Atlas-helm-chart
@@ -127,19 +127,19 @@ Here we define a ClusterIssuer using cert-manager on the cert-manager namespace:
 
 6. Check that it is running:
   ```bash
-  kubectl get clusterissuer -n cert-manager 
+  kubectl get clusterissuer -n cert-manager
   ```
   It is running when Ready is True.
 
 ![img.png](img.png)
 
-##### Create SSL certificate 
-This is needed if you installed cert-manager from the required packages. 
+##### Create SSL certificate
+This is needed if you installed cert-manager from the required packages.
 
 0. Assumes you have a DNS linked to the external IP of the ingress controller
 1. Move to the directory of Aurelius-Atlas-helm-chart
 2. Uncomment templates/certificate.yaml
-3. Update the values.yaml file ``{{ .Values.ingress.dns_url}}`` to your DNS name 
+3. Update the values.yaml file ``{{ .Values.ingress.dns_url}}`` to your DNS name
 4. Create the certificate with the following command
   ```bash
   helm template -s templates/certificate.yaml . | kubectl apply -f -
@@ -148,7 +148,7 @@ This is needed if you installed cert-manager from the required packages.
 
 6. Check that it is approved:
   ```bash
-  kubectl get certificate -n cert-manager 
+  kubectl get certificate -n cert-manager
   ```
   It is running when Ready is True.
 
@@ -160,7 +160,7 @@ Deploy Aurelius Atlas
 -------------------------
 
 1. Update the values.yaml file
-   - ``{{ .Values.keycloak.keycloakFrontendURL }}`` replace it to your DNS name 
+   - ``{{ .Values.keycloak.keycloakFrontendURL }}`` replace it to your DNS name
    - ``{{ .Values.kafka-ui. ... .bootstrapServers }}`` edit it with your `<namespace>`
    - ``{{ .Values.kafka-ui. ... .SERVER_SERVLET_CONTEXT_PATH }}`` edit it with your `<namespace>`
 2. Create the namespace
@@ -174,7 +174,7 @@ Deploy Aurelius Atlas
     ```bash
     cd Aurelius-Atlas-helm-chart
     helm dependency update
-    helm install --generate-name -n <namespace>  -f values.yaml .
+    helm install --generate-name -n <namespace>  -f values.yaml --wait --timeout 15m0s .
     ```
 
 Please note that it can take 5-10 minutes to deploy all services.
@@ -199,7 +199,7 @@ The 5 base users are:
 4. Atlas Data User
 5. Elastic User
 
-To get the randomized passwords out of kubernetes there is a bash script get_passwords. 
+To get the randomized passwords out of kubernetes there is a bash script get_passwords.
 
 ```bash
 ./get_passwords.sh <namespace>
@@ -249,7 +249,7 @@ cd ../py_libs/m4i-flink-tasks/scripts
 /opt/flink/bin/flink run -d -py determine_change_job.py
 /opt/flink/bin/flink run -d -py synchronize_appsearch_job.py
 /opt/flink/bin/flink run -d -py local_operation_job.py
-## To Load the Sample Demo Data 
+## To Load the Sample Demo Data
 cd
 cd init
 ./load_sample_data.sh

--- a/templates/post-install-hook.yaml
+++ b/templates/post-install-hook.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-install-hook
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: post-install-job
+        image: "aureliusatlas/atlas-post-install:main"
+        env:
+          - name: NAMESPACE
+            value: "{{ .Release.Namespace }}"
+          - name: ELASTIC_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: elastic-search-es-elastic-user
+                key: elastic
+          - name: KEYCLOAK_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: keycloak-secret-user-admin
+                key: password
+          - name: KEYCLOAK_USERNAME
+            value: atlas
+          - name: KEYCLOAK_URL
+            value: "https://{{ .Values.global.external_hostname }}/{{ .Release.Namespace }}/auth/"
+          - name: ATLAS_URL
+            value: "https://{{ .Values.global.external_hostname }}/{{ .Release.Namespace }}/atlas2/api/atlas"
+          - name: ELASTIC_URL
+            value: "https://{{ .Values.global.external_hostname }}/{{ .Release.Namespace }}/elastic/"
+          - name: ENTERPRISE_SEARCH_URL
+            value: "https://{{ .Values.global.external_hostname }}/{{ .Release.Namespace }}/app-search/"


### PR DESCRIPTION
Adds a post-install hook that automates creation of search engines and addition of types to atlas

NOTE: check README.md for how to run the `helm install` command now